### PR TITLE
Simple enable/disable auto-update check on boot

### DIFF
--- a/henplugin/main.c
+++ b/henplugin/main.c
@@ -415,6 +415,11 @@ static void henplugin_thread(__attribute__((unused)) uint64_t arg)
 	enable_ingame_screenshot();
 	reload_xmb();
 	CellFsStat stat;
+
+	if(cellFsStat("/dev_hdd0/HEN_autoupdate.off",&stat)==0)
+	{
+		goto done;
+	}
 	
 	if(cellFsStat("/dev_usb000/HEN_UPD.pkg",&stat)==0)
 	{


### PR DESCRIPTION
As proposed on PSX-place.com forums ( https://www.psx-place.com/threads/suggestion-add-no-auto-update-check-option-to-ps3hen.25693/ )

This change adds a check for "/dev_hdd0/HEN_autoupdate.off", 
if the file exists, then disable (skip) the auto-update check on boot.

by default, no file exists and the update check runs on every boot. If the user wants, creates the dummy file and the check is disabled.
