### PR TITLE
Add restoring act.dat from backup

### DIFF
--- a/henplugin/main.c
+++ b/henplugin/main.c
@@ -474,7 +474,7 @@ void restore_act_dat(void)
 		sprintf(path1, "/dev_hdd0/home/%08d/exdata/act.bak", i);
 		sprintf(path2, "/dev_hdd0/home/%08d/exdata/act.dat", i);
 		
-		if((cellFsStat(path1,&stat)==0) && (cellFsStat(path1,&stat)!=0))
+		if((cellFsStat(path1,&stat)==0) && (cellFsStat(path2,&stat)!=0))
 		{
 			// copy act.bak to act.dat
 			if(cellFsOpen(path1, CELL_FS_O_RDONLY, &fd, NULL, 0) != CELL_FS_SUCCEEDED)

--- a/henplugin/main.c
+++ b/henplugin/main.c
@@ -470,7 +470,7 @@ void restore_act_dat(void)
         CellFsStat stat;
         char path1[64], path2[64];
         CellFsDirent dir;
-		uint64_t read;
+        uint64_t read;
 
         while (cellFsReaddir(fd, &dir, &read) == CELL_FS_SUCCEEDED)
         {

--- a/henplugin/main.c
+++ b/henplugin/main.c
@@ -529,7 +529,7 @@ static void henplugin_thread(__attribute__((unused)) uint64_t arg)
 		}
 		goto done;
 	}
-	int do_update=hen_updater();
+	int do_update=(cellFsStat("/dev_hdd0/hen_updater.off",&stat) ? hen_updater() : 0);
 	if((cellFsStat("/dev_flash/vsh/resource/explore/icon/hen_enable.png",&stat)!=0) || (do_update==1))
 	{
 		cellFsUnlink("/dev_hdd0/theme/PS3HEN.p3t");

--- a/henplugin/main.c
+++ b/henplugin/main.c
@@ -493,13 +493,9 @@ static void henplugin_thread(__attribute__((unused)) uint64_t arg)
 	int view = View_Find("explore_plugin");
 	system_call_1(8, SYSCALL8_OPCODE_HEN_REV); hen_version = (int)p1;
 	char henver[0x30];
-	//sprintf(henver, "Welcome to PS3HEN %X.%02X", hen_version>>8, (hen_version & 0xFF));
 	sprintf(henver, "Welcome to PS3HEN %X.%X.%X", hen_version>>8, (hen_version & 0xF0)>>4, (hen_version&0xF));
 	
 	show_msg((char *)henver);
-	
-	// restore act.dat from act.bak backup
-	restore_act_dat();
 	
 	if(view==0)
 	{
@@ -510,6 +506,8 @@ static void henplugin_thread(__attribute__((unused)) uint64_t arg)
 	
 	enable_ingame_screenshot();
 	reload_xmb();
+	// restore act.dat from act.bak backup
+	restore_act_dat();
 	CellFsStat stat;
 	
 	if(cellFsStat("/dev_usb000/HEN_UPD.pkg",&stat)==0)


### PR DESCRIPTION
On HFW, fake `act.dat` files get erased on boot. The user can restore a backup manually or re-activate the console offline each time, but it can be annoying.

This change adds support to automatically restore `act.dat` files from an `act.bak` backup for any user.

Copying `/dev_hdd0/home/0000xxxx/exdata/act.bak` ➡️  `/dev_hdd0/home/0000xxxx/exdata/act.dat`