### PR TITLE
Add restore act.dat from backup (new version)

### DIFF
--- a/henplugin/main.c
+++ b/henplugin/main.c
@@ -474,7 +474,7 @@ void restore_act_dat(void)
 		sprintf(path1, "/dev_hdd0/home/%08d/exdata/act.bak", i);
 		sprintf(path2, "/dev_hdd0/home/%08d/exdata/act.dat", i);
 		
-		if((cellFsStat(path1,&stat)==0) && (cellFsStat(path1,&stat)!=0))
+		if((cellFsStat(path1,&stat)==0) && (cellFsStat(path2,&stat)!=0))
 		{
 			// copy act.bak to act.dat
 			if(cellFsOpen(path1, CELL_FS_O_RDONLY, &fd, NULL, 0) != CELL_FS_SUCCEEDED)

--- a/henplugin/main.c
+++ b/henplugin/main.c
@@ -499,13 +499,9 @@ static void henplugin_thread(__attribute__((unused)) uint64_t arg)
 	int view = View_Find("explore_plugin");
 	system_call_1(8, SYSCALL8_OPCODE_HEN_REV); hen_version = (int)p1;
 	char henver[0x30];
-	//sprintf(henver, "Welcome to PS3HEN %X.%02X", hen_version>>8, (hen_version & 0xFF));
 	sprintf(henver, "Welcome to PS3HEN %X.%X.%X", hen_version>>8, (hen_version & 0xF0)>>4, (hen_version&0xF));
 	
 	show_msg((char *)henver);
-	
-	// restore act.dat from act.bak backup
-	restore_act_dat();
 	
 	if(view==0)
 	{
@@ -516,6 +512,8 @@ static void henplugin_thread(__attribute__((unused)) uint64_t arg)
 	
 	enable_ingame_screenshot();
 	reload_xmb();
+	// restore act.dat from act.bak backup
+	restore_act_dat();
 	CellFsStat stat;
 	
 	if(cellFsStat("/dev_usb000/HEN_UPD.pkg",&stat)==0)

--- a/henplugin/main.c
+++ b/henplugin/main.c
@@ -460,21 +460,15 @@ void restore_act_dat(void)
 	CellFsStat stat;
 	char path1[64], path2[64];
 	uint8_t actdat[4152];
-	int fd, max_uid = 0;
+	int fd, max_uid = 100;
 	uint64_t read;
-
-	if(cellFsOpen("/dev_flash2/etc/savedLastCreatedUserId", CELL_FS_O_RDONLY, &fd, NULL, 0) != CELL_FS_SUCCEEDED)
-		return;
-		
-	cellFsRead(fd, (void *) &max_uid, 4, &read);
-	cellFsClose(fd);
 
 	for (int i = 1; i <= max_uid; i++)
 	{
 		sprintf(path1, "/dev_hdd0/home/%08d/exdata/act.bak", i);
 		sprintf(path2, "/dev_hdd0/home/%08d/exdata/act.dat", i);
 		
-		if((cellFsStat(path1,&stat)==0) && (cellFsStat(path2,&stat)!=0))
+		if((cellFsStat(path1,&stat) == CELL_FS_SUCCEEDED) && (cellFsStat(path2,&stat) != CELL_FS_SUCCEEDED))
 		{
 			// copy act.bak to act.dat
 			if(cellFsOpen(path1, CELL_FS_O_RDONLY, &fd, NULL, 0) != CELL_FS_SUCCEEDED)


### PR DESCRIPTION
This change adds support to automatically restore `act.dat` files from an `act.bak` backup for any user. 
It copies /dev_hdd0/home/00000xxx/exdata/act.bak to  /dev_hdd0/home/00000xxx/exdata/act.dat

This simplified version should address the infinite looping from the previous code:
- hardcoded loop (from userID=1 to userID=100), no possible infinite loop
- copy the file with FsRead/FsWrite , no file linking, no other dependencies
