### PR TITLE
Mamba 8.4 changes by OsirisX

### DIFF
--- a/payload/main.c
+++ b/payload/main.c
@@ -1345,6 +1345,9 @@ LV2_SYSCALL2(int64_t, syscall8, (uint64_t function, uint64_t param1, uint64_t pa
 				case PS3MAPI_OPCODE_PROC_PAGE_ALLOCATE:
 					return ps3mapi_process_page_allocate((process_id_t)param2, param3, param4, param5, param6, (uint64_t *)param7);
 				break;
+				case PS3MAPI_OPCODE_PROC_PAGE_FREE:
+					return ps3mapi_process_page_free((process_id_t)param2, param3, (uint64_t *)param4);
+				break;
 				//----------
 				//MODULE
 				//----------

--- a/payload/ps3mapi_core.h
+++ b/payload/ps3mapi_core.h
@@ -157,11 +157,13 @@ int ps3mapi_get_current_process(process_t process);
 
 #define PS3MAPI_OPCODE_GET_PROC_MEM				0x0031
 #define PS3MAPI_OPCODE_SET_PROC_MEM				0x0032
-#define PS3MAPI_OPCODE_PROC_PAGE_ALLOCATE			0x0033
+#define PS3MAPI_OPCODE_PROC_PAGE_ALLOCATE		0x0033
+#define PS3MAPI_OPCODE_PROC_PAGE_FREE			0x0034
 
 int ps3mapi_set_process_mem(process_id_t pid, uint64_t addr, char *buf, int size);
 int ps3mapi_get_process_mem(process_id_t pid, uint64_t addr, char *buf, int size);
-int ps3mapi_process_page_allocate(process_id_t pid, uint64_t size, uint64_t page_size, uint64_t flags, uint64_t is_executable, uint64_t *page_address);
+int ps3mapi_process_page_allocate(process_id_t pid, uint64_t size, uint64_t page_size, uint64_t flags, uint64_t is_executable, uint64_t *page_table);
+int ps3mapi_process_page_free(process_id_t pid, uint64_t flags, uint64_t *page_table);
 
 //-----------------------------------------------
 //MODULES

--- a/payload/ps3mapi_core.h
+++ b/payload/ps3mapi_core.h
@@ -18,7 +18,7 @@
 //CORE
 //-----------------------------------------------
 
-#define PS3MAPI_CORE_VERSION			 		0x0121
+#define PS3MAPI_CORE_VERSION			 		0x0124
 #define PS3MAPI_CORE_MINVERSION			 		0x0111
 
 #if defined(FIRMWARE_4_82)


### PR DESCRIPTION
- Modify `ps3mapi_process_page_allocate` to use page_table as input and output process and kernel page_address mapping that has been allocated
- Add `ps3mapi_process_page_free` which takes page_table (the process/kernel page_address mappping) and frees it

by @osirizx