### PR TITLE
Update mappath.c

### DIFF
--- a/payload/mappath.c
+++ b/payload/mappath.c
@@ -1206,7 +1206,8 @@ LV2_HOOKED_FUNCTION_POSTCALL_2(int, open_path_hook, (char *path0, char *path1))
 			}
 
 			uint8_t is_ps2_classic = !strncmp(content_id, "2P0001-PS2U10000_00-0000111122223333", 0x24);
-			if(path_chk == 0 || is_ps2_classic)
+			uint8_t is_psp_launcher = !strncmp(content_id, "UP0001-PSPC66820_00-0000111122223333", 0x24);
+			if(path_chk == 0 || is_ps2_classic || is_psp_launcher)
 			{
 				uint8_t rap[0x10] = {0xF5, 0xDE, 0xCA, 0xBB, 0x09, 0x88, 0x4F, 0xF4, 0x02, 0xD4, 0x12, 0x3C, 0x25, 0x01, 0x71, 0xD9};
 				uint8_t idps[0x10];
@@ -1229,7 +1230,7 @@ LV2_HOOKED_FUNCTION_POSTCALL_2(int, open_path_hook, (char *path0, char *path1))
 				int fd;
 				uint64_t nread;
 
-				if(!is_ps2_classic)
+				if(!is_ps2_classic || !is_psp_launcher)					
 				{
 					// uncomment this to avoid hook recursivity & remappings if appropriate
 					//lock_mtx(&pgui_mtx);


### PR DESCRIPTION
Reverted removal of is_psp_launcher variable from commit 69805cad6c43330d01ad3e6a03f68e217728a237.